### PR TITLE
Update wyklad3.tex

### DIFF
--- a/tex/wyklad3.tex
+++ b/tex/wyklad3.tex
@@ -90,7 +90,7 @@ ale $d_x(x,y) = ||x-y||, d_{\mathbb{R}^1} (x,y) = |x-y|$.
 Chcemy pokazać, że $\underset{\epsilon > 0}{\forall} \underset{\delta}{\exists} \underset{x}{\forall} \quad ||x - x_0|| < \delta \implies \big | ||x|| - ||x_0|| \big | < \epsilon$\\
 ale $||x|| = ||x-y+y|| \leq ||x-y|| + ||y||, ||x||-||y||\leq ||x-y||$,\\
 $||y|| = ||y-x+x||\leq ||y-x|| + ||x||$,\\
-$||y||-||x||\leq ||x-y||$, czyli $\big | ||x|| - ||y|| \big | \leq ||x-y||$. Niech $\delta = \frac{\epsilon}{2}$, otrzymujemy $\epsilon > \frac{\epsilon}{2} > ||x-y|| \leq \big | ||x|| - ||y|| \big | \geq 0 \Box$
+$||y||-||x||\leq ||x-y||$, czyli $\big | ||x|| - ||y|| \big | \leq ||x-y||$. Niech $\delta = \frac{\epsilon}{2}$, otrzymujemy $\epsilon > \frac{\epsilon}{2} > ||x-y|| \geq \big | ||x|| - ||y|| \big | \geq 0 \Box$
 
 \begin{pytanie}
 Niech $f(x,y) = 7x+6y^2 \text{ i } g(t) = \left [ \begin{matrix}


### PR DESCRIPTION
W linijce 93 jest powinna być odwrotna nierówność (w ostatniej) : 
zamiast
||x-y|| \leq \big | ||x|| - ||y|
powinno być |
||x-y|| \geq \big | ||x|| - ||y||

||x-y|| \geq \big | ||x|| - ||y||